### PR TITLE
Add live stats panel with pause/resume/reset controls

### DIFF
--- a/libs/simulation-wasm/src/lib.rs
+++ b/libs/simulation-wasm/src/lib.rs
@@ -29,13 +29,27 @@ impl Simulation {
         JsValue::from_serde(&world).unwrap()
     }
 
-    pub fn step(&mut self) {
-        self.sim.step(&mut self.rng);
+    /// Advances the simulation by a single step.
+    ///
+    /// Returns a formatted statistics string whenever a generation has just
+    /// finished (i.e. the population evolved), or `None` otherwise.
+    pub fn step(&mut self) -> Option<String> {
+        self.sim.step(&mut self.rng).map(|stats| Self::format_stats(&stats))
     }
 
     pub fn train(&mut self) -> String {
         let stats = self.sim.train(&mut self.rng);
 
+        Self::format_stats(&stats)
+    }
+
+    /// Current generation number (how many times the population has
+    /// evolved so far).
+    pub fn generation(&self) -> usize {
+        self.sim.generation()
+    }
+
+    fn format_stats(stats: &sim::Statistics) -> String {
         format!(
             "min={:.2}, max={:.2}, avg={:.2}",
             stats.min_fitness(),

--- a/libs/simulation-wasm/src/lib.rs
+++ b/libs/simulation-wasm/src/lib.rs
@@ -8,6 +8,14 @@ mod animal;
 mod food;
 mod world;
 
+#[derive(Debug, Clone, Serialize)]
+pub struct GenerationStats {
+    pub generation: usize,
+    pub min_fitness: f32,
+    pub max_fitness: f32,
+    pub avg_fitness: f32,
+}
+
 #[wasm_bindgen]
 pub struct Simulation {
     rng: ThreadRng,
@@ -31,16 +39,19 @@ impl Simulation {
 
     /// Advances the simulation by a single step.
     ///
-    /// Returns a formatted statistics string whenever a generation has just
+    /// Returns structured statistics whenever a generation has just
     /// finished (i.e. the population evolved), or `None` otherwise.
-    pub fn step(&mut self) -> Option<String> {
-        self.sim.step(&mut self.rng).map(|stats| Self::format_stats(&stats))
+    pub fn step(&mut self) -> JsValue {
+        match self.sim.step(&mut self.rng) {
+            Some(stats) => JsValue::from_serde(&self.generation_stats(&stats)).unwrap(),
+            None => JsValue::NULL,
+        }
     }
 
-    pub fn train(&mut self) -> String {
+    pub fn train(&mut self) -> JsValue {
         let stats = self.sim.train(&mut self.rng);
 
-        Self::format_stats(&stats)
+        JsValue::from_serde(&self.generation_stats(&stats)).unwrap()
     }
 
     /// Current generation number (how many times the population has
@@ -49,13 +60,13 @@ impl Simulation {
         self.sim.generation()
     }
 
-    fn format_stats(stats: &sim::Statistics) -> String {
-        format!(
-            "min={:.2}, max={:.2}, avg={:.2}",
-            stats.min_fitness(),
-            stats.max_fitness(),
-            stats.avg_fitness(),
-        )
+    fn generation_stats(&self, stats: &sim::Statistics) -> GenerationStats {
+        GenerationStats {
+            generation: self.sim.generation(),
+            min_fitness: stats.min_fitness(),
+            max_fitness: stats.max_fitness(),
+            avg_fitness: stats.avg_fitness(),
+        }
     }
 }
 

--- a/libs/simulation/src/lib.rs
+++ b/libs/simulation/src/lib.rs
@@ -1,4 +1,5 @@
 pub use self::{animal::*, animal_individual::*, brain::*, eye::*, food::*, world::*};
+pub use lib_genetic_algorithm::Statistics;
 use lib_genetic_algorithm as ga;
 use lib_neural_network as nn;
 use nalgebra as na;
@@ -64,6 +65,7 @@ pub struct Simulation {
     world: World,
     ga: ga::GeneticAlgorithm<ga::RouletteWheelSelection>,
     age: usize,
+    generation: usize,
 }
 
 impl Simulation {
@@ -76,11 +78,21 @@ impl Simulation {
             ga::GaussianMutation::new(0.01, 0.3),
         );
 
-        Self { world, ga, age: 0 }
+        Self {
+            world,
+            ga,
+            age: 0,
+            generation: 0,
+        }
     }
 
     pub fn world(&self) -> &World {
         &self.world
+    }
+
+    /// Returns how many full generations have been completed so far.
+    pub fn generation(&self) -> usize {
+        self.generation
     }
 
     /// Performs a single step - a single second, so to say - of our simulation
@@ -150,6 +162,7 @@ impl Simulation {
 
     fn evolve(&mut self, rng: &mut dyn Rng) -> ga::Statistics {
         self.age = 0;
+        self.generation += 1;
 
         // Step 1: Prepeare birdies to be sent into genetic algorithm
         let current_population: Vec<_> = self

--- a/www/index.html
+++ b/www/index.html
@@ -50,6 +50,37 @@
   #stats span {
     font-weight: bold;
   }
+
+  #chart-container {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    margin: 15px;
+    padding: 10px 14px;
+    border-radius: 6px;
+    background: rgba(59, 70, 100, 0.85);
+    color: #e6e9f0;
+    font-size: 12px;
+  }
+
+  #chart-legend {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 6px;
+  }
+
+  #chart-legend span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  #chart-legend i {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+  }
 </style>
 
 <body>
@@ -66,6 +97,15 @@
     min fitness: <span id="stat-min">-</span><br>
     max fitness: <span id="stat-max">-</span><br>
     avg fitness: <span id="stat-avg">-</span>
+  </div>
+
+  <div id="chart-container">
+    <div id="chart-legend">
+      <span><i style="background: rgb(255, 99, 99)"></i>max</span>
+      <span><i style="background: rgb(255, 220, 99)"></i>avg</span>
+      <span><i style="background: rgb(99, 170, 255)"></i>min</span>
+    </div>
+    <canvas id="chart" width="360" height="140"></canvas>
   </div>
 
   <script src="./bootstrap.js"></script>

--- a/www/index.html
+++ b/www/index.html
@@ -8,18 +8,66 @@
 <style>
   body {
     background: #1f2639;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   }
 
-  #train {
+  #controls {
     position: absolute;
     top: 0;
+    left: 0;
     margin: 15px;
+    display: flex;
+    gap: 8px;
+  }
+
+  #controls button {
+    cursor: pointer;
+    padding: 6px 12px;
+    border: none;
+    border-radius: 4px;
+    background: #3b4664;
+    color: #e6e9f0;
+  }
+
+  #controls button:hover {
+    background: #4c5a80;
+  }
+
+  #stats {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 15px;
+    padding: 10px 14px;
+    border-radius: 6px;
+    background: rgba(59, 70, 100, 0.85);
+    color: #e6e9f0;
+    font-size: 14px;
+    line-height: 1.6;
+    min-width: 180px;
+  }
+
+  #stats span {
+    font-weight: bold;
   }
 </style>
 
 <body>
   <canvas id="viewport" width="800" , height="800"></canvas>
-  <button id="train">train please, thank u</button>
+
+  <div id="controls">
+    <button id="train">train please, thank u</button>
+    <button id="pause">pause</button>
+    <button id="reset">reset</button>
+  </div>
+
+  <div id="stats">
+    generation: <span id="stat-generation">0</span><br>
+    min fitness: <span id="stat-min">-</span><br>
+    max fitness: <span id="stat-max">-</span><br>
+    avg fitness: <span id="stat-avg">-</span>
+  </div>
+
   <script src="./bootstrap.js"></script>
 </body>
 

--- a/www/index.js
+++ b/www/index.js
@@ -2,14 +2,57 @@ import * as sim from "lib-simulation-wasm"
 
 let simulation = new sim.Simulation();
 
-document.getElementById('train').onclick = function () {
-    console.log(simulation.train())
-}
-
 const viewport = document.getElementById('viewport');
 const viewportWidth = viewport.width;
 const viewportHeight = viewport.height;
 const ctxt = viewport.getContext('2d');
+
+const pauseBtn = document.getElementById('pause');
+const resetBtn = document.getElementById('reset');
+const trainBtn = document.getElementById('train');
+
+const statGeneration = document.getElementById('stat-generation');
+const statMin = document.getElementById('stat-min');
+const statMax = document.getElementById('stat-max');
+const statAvg = document.getElementById('stat-avg');
+
+let isPaused = false;
+
+function updateStats(statsString) {
+    statGeneration.textContent = simulation.generation();
+
+    if (!statsString) {
+        return;
+    }
+
+    // statsString looks like: "min=0.12, max=3.45, avg=1.23"
+    const matches = statsString.match(/min=([\d.-]+), max=([\d.-]+), avg=([\d.-]+)/);
+
+    if (matches) {
+        statMin.textContent = matches[1];
+        statMax.textContent = matches[2];
+        statAvg.textContent = matches[3];
+    }
+}
+
+trainBtn.onclick = function () {
+    const stats = simulation.train();
+    console.log(stats);
+    updateStats(stats);
+};
+
+pauseBtn.onclick = function () {
+    isPaused = !isPaused;
+    pauseBtn.textContent = isPaused ? 'resume' : 'pause';
+};
+
+resetBtn.onclick = function () {
+    simulation = new sim.Simulation();
+    statMin.textContent = '-';
+    statMax.textContent = '-';
+    statAvg.textContent = '-';
+    updateStats(null);
+};
 
 CanvasRenderingContext2D.prototype.drawTriangle = function (x, y, size, rotation) {
     this.beginPath();
@@ -50,27 +93,35 @@ CanvasRenderingContext2D.prototype.drawCircle = function (x, y, radius) {
 }
 
 function redraw() {
-    ctxt.clearRect(0, 0, viewportWidth, viewportHeight);
+    if (!isPaused) {
+        ctxt.clearRect(0, 0, viewportWidth, viewportHeight);
 
-    simulation.step();
+        const stats = simulation.step();
 
-    const world = simulation.world();
+        if (stats) {
+            console.log(stats);
+        }
 
-    for (const food of world.foods) {
-        ctxt.drawCircle(
-            food.x * viewportWidth,
-            food.y * viewportHeight,
-            (0.01 / 2.0) * viewportWidth,
-        );
-    }
+        updateStats(stats);
 
-    for (const animal of world.animals) {
-        ctxt.drawTriangle(
-            animal.x * viewportWidth,
-            animal.y * viewportHeight,
-            0.01 * viewportWidth,
-            animal.rotation,
-        );
+        const world = simulation.world();
+
+        for (const food of world.foods) {
+            ctxt.drawCircle(
+                food.x * viewportWidth,
+                food.y * viewportHeight,
+                (0.01 / 2.0) * viewportWidth,
+            );
+        }
+
+        for (const animal of world.animals) {
+            ctxt.drawTriangle(
+                animal.x * viewportWidth,
+                animal.y * viewportHeight,
+                0.01 * viewportWidth,
+                animal.rotation,
+            );
+        }
     }
 
     // requestAnimationFrame() schedules code only for the next frame.

--- a/www/index.js
+++ b/www/index.js
@@ -7,6 +7,11 @@ const viewportWidth = viewport.width;
 const viewportHeight = viewport.height;
 const ctxt = viewport.getContext('2d');
 
+const chart = document.getElementById('chart');
+const chartWidth = chart.width;
+const chartHeight = chart.height;
+const chartCtxt = chart.getContext('2d');
+
 const pauseBtn = document.getElementById('pause');
 const resetBtn = document.getElementById('reset');
 const trainBtn = document.getElementById('train');
@@ -18,27 +23,87 @@ const statAvg = document.getElementById('stat-avg');
 
 let isPaused = false;
 
-function updateStats(statsString) {
+// History of per-generation fitness stats, used to draw the chart.
+// Capped so the chart stays readable and memory bounded over long runs.
+const MAX_HISTORY = 200;
+let statsHistory = [];
+
+function recordStats(stats) {
     statGeneration.textContent = simulation.generation();
 
-    if (!statsString) {
+    if (!stats) {
         return;
     }
 
-    // statsString looks like: "min=0.12, max=3.45, avg=1.23"
-    const matches = statsString.match(/min=([\d.-]+), max=([\d.-]+), avg=([\d.-]+)/);
+    statMin.textContent = stats.min_fitness.toFixed(2);
+    statMax.textContent = stats.max_fitness.toFixed(2);
+    statAvg.textContent = stats.avg_fitness.toFixed(2);
 
-    if (matches) {
-        statMin.textContent = matches[1];
-        statMax.textContent = matches[2];
-        statAvg.textContent = matches[3];
+    statsHistory.push(stats);
+
+    if (statsHistory.length > MAX_HISTORY) {
+        statsHistory.shift();
     }
+
+    drawChart();
+}
+
+function resetStats() {
+    statMin.textContent = '-';
+    statMax.textContent = '-';
+    statAvg.textContent = '-';
+    statsHistory = [];
+    drawChart();
+}
+
+function drawChart() {
+    chartCtxt.clearRect(0, 0, chartWidth, chartHeight);
+
+    if (statsHistory.length === 0) {
+        return;
+    }
+
+    const allFitness = statsHistory.flatMap((s) => [s.min_fitness, s.max_fitness]);
+    const loFitness = Math.min(...allFitness);
+    const hiFitness = Math.max(...allFitness, loFitness + 0.001);
+
+    const xStep = statsHistory.length > 1
+        ? chartWidth / (statsHistory.length - 1)
+        : 0;
+
+    function toY(fitness) {
+        const t = (fitness - loFitness) / (hiFitness - loFitness);
+        return chartHeight - t * chartHeight;
+    }
+
+    function drawLine(color, valueOf) {
+        chartCtxt.beginPath();
+        chartCtxt.strokeStyle = color;
+        chartCtxt.lineWidth = 1.5;
+
+        statsHistory.forEach((s, i) => {
+            const x = i * xStep;
+            const y = toY(valueOf(s));
+
+            if (i === 0) {
+                chartCtxt.moveTo(x, y);
+            } else {
+                chartCtxt.lineTo(x, y);
+            }
+        });
+
+        chartCtxt.stroke();
+    }
+
+    drawLine('rgb(255, 99, 99)', (s) => s.max_fitness);
+    drawLine('rgb(255, 220, 99)', (s) => s.avg_fitness);
+    drawLine('rgb(99, 170, 255)', (s) => s.min_fitness);
 }
 
 trainBtn.onclick = function () {
     const stats = simulation.train();
     console.log(stats);
-    updateStats(stats);
+    recordStats(stats);
 };
 
 pauseBtn.onclick = function () {
@@ -48,10 +113,7 @@ pauseBtn.onclick = function () {
 
 resetBtn.onclick = function () {
     simulation = new sim.Simulation();
-    statMin.textContent = '-';
-    statMax.textContent = '-';
-    statAvg.textContent = '-';
-    updateStats(null);
+    resetStats();
 };
 
 CanvasRenderingContext2D.prototype.drawTriangle = function (x, y, size, rotation) {
@@ -102,7 +164,7 @@ function redraw() {
             console.log(stats);
         }
 
-        updateStats(stats);
+        recordStats(stats);
 
         const world = simulation.world();
 

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -12,9 +12,9 @@
         "create-wasm-app": ".bin/create-wasm-app.js"
       },
       "devDependencies": {
-        "copy-webpack-plugin": "^14.0.0",
+        "copy-webpack-plugin": "^12.0.2",
         "hello-wasm-pack": "^0.1.0",
-        "lib-simulation-wasm": "file: ../libs/simulation-wasm/pkg",
+        "lib-simulation-wasm": "file:../libs/simulation-wasm/pkg",
         "webpack": "^5.99.7",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.1"
@@ -23,12 +23,12 @@
     " ../libs/simulation-wasm/pkg": {
       "name": "lib-simulation-wasm",
       "version": "0.0.1",
-      "dev": true
+      "extraneous": true
     },
     "../libs/simulation-wasm/pkg": {
       "name": "lib-simulation-wasm",
-      "version": "0.0.1",
-      "extraneous": true
+      "version": "0.1.0",
+      "dev": true
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",
@@ -154,6 +154,41 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@peculiar/asn1-cms": {
@@ -311,6 +346,18 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@types/body-parser": {
@@ -1222,19 +1269,20 @@
       "dev": true
     },
     "node_modules/copy-webpack-plugin": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
-      "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+      "integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
       "dev": true,
       "dependencies": {
+        "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.1",
+        "globby": "^14.0.0",
         "normalize-path": "^3.0.0",
         "schema-utils": "^4.2.0",
-        "serialize-javascript": "^7.0.3",
-        "tinyglobby": "^0.2.12"
+        "serialize-javascript": "^6.0.2"
       },
       "engines": {
-        "node": ">= 20.9.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1242,15 +1290,6 @@
       },
       "peerDependencies": {
         "webpack": "^5.1.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
-      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
-      "dev": true,
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/core-util-is": {
@@ -1609,6 +1648,34 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -1630,6 +1697,15 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
@@ -1792,6 +1868,26 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1952,6 +2048,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/import-local": {
@@ -2257,7 +2362,7 @@
       }
     },
     "node_modules/lib-simulation-wasm": {
-      "resolved": " ../libs/simulation-wasm/pkg",
+      "resolved": "../libs/simulation-wasm/pkg",
       "link": true
     },
     "node_modules/math-intrinsics": {
@@ -2311,6 +2416,15 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -2613,6 +2727,18 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true
     },
+    "node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2708,6 +2834,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -2873,6 +3028,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
@@ -2883,6 +3048,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -2973,6 +3161,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
     },
     "node_modules/serve-index": {
       "version": "1.9.1",
@@ -3173,6 +3370,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sockjs": {
@@ -3389,51 +3598,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
-    "node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3513,6 +3677,18 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -3972,6 +4148,32 @@
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "dev": true
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@peculiar/asn1-cms": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
@@ -4125,6 +4327,12 @@
         "tslib": "^2.8.1",
         "tsyringe": "^4.10.0"
       }
+    },
+    "@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true
     },
     "@types/body-parser": {
       "version": "1.19.5",
@@ -4834,24 +5042,17 @@
       "dev": true
     },
     "copy-webpack-plugin": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
-      "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+      "integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
       "dev": true,
       "requires": {
+        "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.1",
+        "globby": "^14.0.0",
         "normalize-path": "^3.0.0",
         "schema-utils": "^4.2.0",
-        "serialize-javascript": "^7.0.3",
-        "tinyglobby": "^0.2.12"
-      },
-      "dependencies": {
-        "serialize-javascript": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
-          "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
-          "dev": true
-        }
+        "serialize-javascript": "^6.0.2"
       }
     },
     "core-util-is": {
@@ -5117,6 +5318,30 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
     "fast-uri": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -5128,6 +5353,15 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "faye-websocket": {
       "version": "0.11.4",
@@ -5234,6 +5468,20 @@
       "dev": true,
       "requires": {
         "is-glob": "^4.0.3"
+      }
+    },
+    "globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
       }
     },
     "gopd": {
@@ -5356,6 +5604,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true
     },
     "import-local": {
       "version": "3.1.0",
@@ -5566,7 +5820,7 @@
       }
     },
     "lib-simulation-wasm": {
-      "version": "file: ../libs/simulation-wasm/pkg"
+      "version": "file:../libs/simulation-wasm/pkg"
     },
     "math-intrinsics": {
       "version": "1.1.0",
@@ -5602,6 +5856,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "methods": {
@@ -5788,6 +6048,12 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true
     },
+    "path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5861,6 +6127,21 @@
       "requires": {
         "es-define-property": "^1.0.1",
         "side-channel": "^1.1.1"
+      }
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -5985,11 +6266,26 @@
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true
+    },
     "run-applescript": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
       "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
       "dev": true
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -6064,6 +6360,15 @@
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
+      }
+    },
+    "serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "serve-index": {
@@ -6214,6 +6519,12 @@
         "object-inspect": "^1.13.3",
         "side-channel-map": "^1.0.1"
       }
+    },
+    "slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true
     },
     "sockjs": {
       "version": "0.3.24",
@@ -6375,31 +6686,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
-    "tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
-      "requires": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "dependencies": {
-        "fdir": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-          "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true,
-          "requires": {}
-        },
-        "picomatch": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-          "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-          "dev": true
-        }
-      }
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6459,6 +6745,12 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
+    "unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true
     },
     "unpipe": {

--- a/www/package.json
+++ b/www/package.json
@@ -27,9 +27,9 @@
   },
   "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
   "devDependencies": {
-    "copy-webpack-plugin": "^14.0.0",
+    "copy-webpack-plugin": "^12.0.2",
     "hello-wasm-pack": "^0.1.0",
-    "lib-simulation-wasm": "file: ../libs/simulation-wasm/pkg",
+    "lib-simulation-wasm": "file:../libs/simulation-wasm/pkg",
     "webpack": "^5.99.7",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.1"


### PR DESCRIPTION
- Track generation count in Simulation and expose it via the WASM bindings
- Return formatted fitness stats from step() whenever a generation completes, instead of discarding them
- Add a live-updating stats panel (generation, min/max/avg fitness) and Pause/Resume/Reset buttons to the frontend
- Fix www/package.json: downgrade copy-webpack-plugin to ^12.0.2 for Node 18 compatibility (v14 requires Node >=20 and uses Array.prototype.toSorted)
- Fix a typo in www/package.json ("file: ../libs/simulation-wasm/pkg" had a stray space) that produced a broken node_modules symlink