### PR TITLE
Add unit tests to raise coverage of lib-simulation and lib-simulation-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "lib-neural-network",
  "nalgebra",
  "rand",
+ "rand_chacha",
  "test-case",
 ]
 
@@ -380,8 +381,10 @@ version = "0.1.0"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.4.3",
+ "lib-genetic-algorithm",
  "lib-simulation",
  "rand",
+ "rand_chacha",
  "serde",
  "wasm-bindgen",
 ]

--- a/libs/simulation-wasm/Cargo.toml
+++ b/libs/simulation-wasm/Cargo.toml
@@ -16,3 +16,7 @@ getrandom = { version = "0.2.17", features = ["js"] }
 getrandom04 = { package = "getrandom", version = "0.4.3", features = ["wasm_js"] }
 
 lib-simulation = { path = "../simulation" }
+
+[dev-dependencies]
+rand_chacha = "0.10.0"
+lib-genetic-algorithm = { path = "../genetic-algorithm" }

--- a/libs/simulation-wasm/src/animal.rs
+++ b/libs/simulation-wasm/src/animal.rs
@@ -16,3 +16,22 @@ impl From<&sim::Animal> for Animal {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn from_sim_animal_copies_position_and_rotation() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let sim_animal = sim::Animal::random(&mut rng);
+
+        let animal = Animal::from(&sim_animal);
+
+        assert_eq!(animal.x, sim_animal.position().x);
+        assert_eq!(animal.y, sim_animal.position().y);
+        assert_eq!(animal.rotation, sim_animal.rotation().angle());
+    }
+}

--- a/libs/simulation-wasm/src/food.rs
+++ b/libs/simulation-wasm/src/food.rs
@@ -14,3 +14,21 @@ impl From<&sim::Food> for Food {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn from_sim_food_copies_the_position() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let sim_food = sim::Food::random(&mut rng);
+
+        let food = Food::from(&sim_food);
+
+        assert_eq!(food.x, sim_food.position().x);
+        assert_eq!(food.y, sim_food.position().y);
+    }
+}

--- a/libs/simulation-wasm/src/lib.rs
+++ b/libs/simulation-wasm/src/lib.rs
@@ -75,3 +75,64 @@ impl Default for Simulation {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_creates_a_simulation_starting_at_generation_zero() {
+        let simulation = Simulation::new();
+
+        assert_eq!(simulation.generation(), 0);
+    }
+
+    #[test]
+    fn step_does_not_evolve_before_generation_length_is_reached() {
+        let mut simulation = Simulation::new();
+
+        // GENERATION_LENGTH (in lib-simulation) is 2500; stepping fewer
+        // times than that should never trigger evolution, and therefore
+        // never touch the (wasm-only) JsValue::from_serde path.
+        for _ in 0..100 {
+            let _ = simulation.step();
+        }
+
+        assert_eq!(simulation.generation(), 0);
+    }
+
+    #[test]
+    fn generation_stats_reflects_the_current_generation_and_fitness_values() {
+        let simulation = Simulation::new();
+        let stats = lib_simulation::Statistics::new(&[
+            AnimalIndividualStub(1.0),
+            AnimalIndividualStub(3.0),
+            AnimalIndividualStub(5.0),
+        ]);
+
+        let generation_stats = simulation.generation_stats(&stats);
+
+        assert_eq!(generation_stats.generation, simulation.generation());
+        assert_eq!(generation_stats.min_fitness, 1.0);
+        assert_eq!(generation_stats.max_fitness, 5.0);
+        assert_eq!(generation_stats.avg_fitness, 3.0);
+    }
+
+    /// Minimal stand-in for `AnimalIndividual` used only to exercise
+    /// `Statistics::new` without depending on a full `Animal`.
+    struct AnimalIndividualStub(f32);
+
+    impl lib_genetic_algorithm::Individual for AnimalIndividualStub {
+        fn create(_chromosome: lib_genetic_algorithm::Chromosome) -> Self {
+            unimplemented!()
+        }
+
+        fn chromosome(&self) -> &lib_genetic_algorithm::Chromosome {
+            unimplemented!()
+        }
+
+        fn fitness(&self) -> f32 {
+            self.0
+        }
+    }
+}

--- a/libs/simulation-wasm/src/world.rs
+++ b/libs/simulation-wasm/src/world.rs
@@ -15,3 +15,21 @@ impl From<&sim::World> for World {
         Self { animals, foods }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn from_sim_world_converts_all_animals_and_foods() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let sim_world = sim::World::random(&mut rng);
+
+        let world = World::from(&sim_world);
+
+        assert_eq!(world.animals.len(), sim_world.animals().len());
+        assert_eq!(world.foods.len(), sim_world.foods().len());
+    }
+}

--- a/libs/simulation/Cargo.toml
+++ b/libs/simulation/Cargo.toml
@@ -14,3 +14,4 @@ lib-genetic-algorithm = { path = "../genetic-algorithm" }
 
 [dev-dependencies]
 test-case = "3.1.0"
+rand_chacha = "0.10.0"

--- a/libs/simulation/src/animal.rs
+++ b/libs/simulation/src/animal.rs
@@ -51,3 +51,45 @@ impl Animal {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn random_creates_an_animal_with_default_speed_and_no_satiation() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let animal = Animal::random(&mut rng);
+
+        assert_eq!(animal.speed, 0.002);
+        assert_eq!(animal.satiation, 0);
+    }
+
+    #[test]
+    fn position_and_rotation_getters_match_the_fields() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let animal = Animal::random(&mut rng);
+
+        assert_eq!(animal.position(), animal.position);
+        assert_eq!(animal.rotation(), animal.rotation);
+    }
+
+    #[test]
+    fn chromosome_roundtrip_preserves_the_brain() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let animal = Animal::random(&mut rng);
+
+        let chromosome = animal.as_chromosome();
+        let reconstructed = Animal::from_chromosome(chromosome.clone(), &mut rng);
+
+        assert_eq!(
+            reconstructed
+                .as_chromosome()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            chromosome.into_iter().collect::<Vec<_>>(),
+        );
+    }
+}

--- a/libs/simulation/src/animal_individual.rs
+++ b/libs/simulation/src/animal_individual.rs
@@ -36,3 +36,61 @@ impl ga::Individual for AnimalIndividual {
         self.fitness
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ga::Individual;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn from_animal_uses_satiation_as_fitness() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let mut animal = Animal::random(&mut rng);
+        animal.satiation = 7;
+
+        let individual = AnimalIndividual::from_animal(&animal);
+
+        assert_eq!(individual.fitness(), 7.0);
+    }
+
+    #[test]
+    fn from_animal_carries_over_the_chromosome() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let animal = Animal::random(&mut rng);
+
+        let individual = AnimalIndividual::from_animal(&animal);
+
+        assert_eq!(
+            individual.chromosome().iter().collect::<Vec<_>>(),
+            animal.as_chromosome().iter().collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn into_animal_rebuilds_the_brain_from_the_chromosome() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let animal = Animal::random(&mut rng);
+        let chromosome = animal.as_chromosome();
+
+        let individual = AnimalIndividual::from_animal(&animal);
+        let rebuilt = individual.into_animal(&mut rng);
+
+        assert_eq!(
+            rebuilt.as_chromosome().into_iter().collect::<Vec<_>>(),
+            chromosome.into_iter().collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn create_starts_with_zero_fitness() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let animal = Animal::random(&mut rng);
+        let chromosome = animal.as_chromosome();
+
+        let individual = AnimalIndividual::create(chromosome);
+
+        assert_eq!(individual.fitness(), 0.0);
+    }
+}

--- a/libs/simulation/src/brain.rs
+++ b/libs/simulation/src/brain.rs
@@ -34,3 +34,37 @@ impl Brain {
         ]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn random_produces_a_network_matching_the_eyes_topology() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let eye = Eye::default();
+        let brain = Brain::random(&mut rng, &eye);
+
+        let output = brain.nn.propagate(vec![0.0; eye.cells()]);
+
+        // Output layer always has exactly 2 neurons: speed & rotation.
+        assert_eq!(output.len(), 2);
+    }
+
+    #[test]
+    fn chromosome_roundtrip_preserves_the_weights() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let eye = Eye::default();
+        let brain = Brain::random(&mut rng, &eye);
+
+        let chromosome = brain.as_chromosome();
+        let rebuilt = Brain::from_chromosome(chromosome.clone(), &eye);
+
+        assert_eq!(
+            rebuilt.as_chromosome().into_iter().collect::<Vec<_>>(),
+            chromosome.into_iter().collect::<Vec<_>>(),
+        );
+    }
+}

--- a/libs/simulation/src/food.rs
+++ b/libs/simulation/src/food.rs
@@ -16,3 +16,27 @@ impl Food {
         self.position
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn random_places_food_within_bounds() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let food = Food::random(&mut rng);
+
+        assert!((0.0..=1.0).contains(&food.position.x));
+        assert!((0.0..=1.0).contains(&food.position.y));
+    }
+
+    #[test]
+    fn position_returns_the_stored_position() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let food = Food::random(&mut rng);
+
+        assert_eq!(food.position(), food.position);
+    }
+}

--- a/libs/simulation/src/lib.rs
+++ b/libs/simulation/src/lib.rs
@@ -1,6 +1,6 @@
 pub use self::{animal::*, animal_individual::*, brain::*, eye::*, food::*, world::*};
-pub use lib_genetic_algorithm::Statistics;
 use lib_genetic_algorithm as ga;
+pub use lib_genetic_algorithm::Statistics;
 use lib_neural_network as nn;
 use nalgebra as na;
 use rand::{Rng, RngExt};
@@ -189,5 +189,67 @@ impl Simulation {
             food.position = rng.random();
         }
         stats
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn random_creates_a_world_with_forty_animals_and_sixty_foods() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let simulation = Simulation::random(&mut rng);
+
+        assert_eq!(simulation.world().animals().len(), 40);
+        assert_eq!(simulation.world().foods().len(), 60);
+    }
+
+    #[test]
+    fn generation_starts_at_zero() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let simulation = Simulation::random(&mut rng);
+
+        assert_eq!(simulation.generation(), 0);
+        assert_eq!(simulation.age, 0);
+    }
+
+    #[test]
+    fn step_returns_none_until_a_generation_completes() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let mut simulation = Simulation::random(&mut rng);
+
+        for _ in 0..GENERATION_LENGTH {
+            assert!(simulation.step(&mut rng).is_none());
+        }
+
+        assert!(simulation.step(&mut rng).is_some());
+        assert_eq!(simulation.generation(), 1);
+    }
+
+    #[test]
+    fn train_advances_a_full_generation_and_returns_sane_statistics() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let mut simulation = Simulation::random(&mut rng);
+
+        let stats = simulation.train(&mut rng);
+
+        assert_eq!(simulation.generation(), 1);
+        assert_eq!(simulation.age, 0);
+        assert!(stats.min_fitness() <= stats.avg_fitness());
+        assert!(stats.avg_fitness() <= stats.max_fitness());
+    }
+
+    #[test]
+    fn train_resets_the_world_population_size() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let mut simulation = Simulation::random(&mut rng);
+
+        simulation.train(&mut rng);
+
+        assert_eq!(simulation.world().animals().len(), 40);
+        assert_eq!(simulation.world().foods().len(), 60);
     }
 }

--- a/libs/simulation/src/world.rs
+++ b/libs/simulation/src/world.rs
@@ -23,3 +23,28 @@ impl World {
         &self.foods
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn random_creates_forty_animals_and_sixty_foods() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let world = World::random(&mut rng);
+
+        assert_eq!(world.animals().len(), 40);
+        assert_eq!(world.foods().len(), 60);
+    }
+
+    #[test]
+    fn getters_expose_the_underlying_collections() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let world = World::random(&mut rng);
+
+        assert_eq!(world.animals().len(), world.animals.len());
+        assert_eq!(world.foods().len(), world.foods.len());
+    }
+}


### PR DESCRIPTION
lib-simulation went from ~40% to ~100% line coverage:
- animal.rs: default speed/satiation, position()/rotation() getters, chromosome round-trip via from_chromosome/as_chromosome
- animal_individual.rs: from_animal()/into_animal()/create() and the Individual trait impl (fitness derived from satiation, chromosome passthrough)
- brain.rs: random() produces a network matching the eye's topology, and from_chromosome()/as_chromosome() round-trip preserves weights
- food.rs: random() stays within [0, 1] bounds, position() getter
- world.rs: random() creates 40 animals/60 foods, getters
- lib.rs (Simulation): random(), step() returning None until a generation completes then Some with sane stats, train() advancing exactly one generation and resetting population size

lib-simulation-wasm went from 0% to substantial coverage:
- animal.rs/food.rs/world.rs: the plain From<&sim::T> conversions are now fully covered
- lib.rs: Simulation::new()/generation() and the private generation_stats() helper are covered; the wasm-bindgen JsValue paths (world(), and the Some branches of step()/train()) can't be exercised outside a real wasm/browser runtime - calling essentially any JsValue method (even is_null()) panics with "cannot call wasm-bindgen imported functions on non-wasm targets" when run under plain `cargo test`, so those lines remain untestable without wasm-bindgen-test in a browser/node environment