### PR TITLE
Add configurable simulation parameters (animals, foods, mutation, speed)

### DIFF
--- a/libs/simulation-wasm/src/lib.rs
+++ b/libs/simulation-wasm/src/lib.rs
@@ -25,9 +25,29 @@ pub struct Simulation {
 #[wasm_bindgen]
 impl Simulation {
     #[wasm_bindgen(constructor)]
-    pub fn new() -> Self {
+    pub fn new(
+        num_animals: Option<usize>,
+        num_foods: Option<usize>,
+        mutation_chance: Option<f32>,
+        mutation_coeff: Option<f32>,
+        max_speed: Option<f32>,
+    ) -> Self {
+        let defaults = sim::Config::default();
+
+        let config = sim::Config {
+            num_animals: num_animals.unwrap_or(defaults.num_animals),
+            num_foods: num_foods.unwrap_or(defaults.num_foods),
+            mutation_chance: mutation_chance
+                .unwrap_or(defaults.mutation_chance)
+                .clamp(0.0, 1.0),
+            mutation_coeff: mutation_coeff
+                .unwrap_or(defaults.mutation_coeff)
+                .clamp(0.0, 1.0),
+            max_speed: max_speed.unwrap_or(defaults.max_speed).max(0.0),
+        };
+
         let mut rng = rand::rng();
-        let sim = sim::Simulation::random(&mut rng);
+        let sim = sim::Simulation::random_with_config(&mut rng, config);
 
         Self { rng, sim }
     }
@@ -72,7 +92,7 @@ impl Simulation {
 
 impl Default for Simulation {
     fn default() -> Self {
-        Self::new()
+        Self::new(None, None, None, None, None)
     }
 }
 
@@ -82,14 +102,14 @@ mod tests {
 
     #[test]
     fn new_creates_a_simulation_starting_at_generation_zero() {
-        let simulation = Simulation::new();
+        let simulation = Simulation::new(None, None, None, None, None);
 
         assert_eq!(simulation.generation(), 0);
     }
 
     #[test]
     fn step_does_not_evolve_before_generation_length_is_reached() {
-        let mut simulation = Simulation::new();
+        let mut simulation = Simulation::new(None, None, None, None, None);
 
         // GENERATION_LENGTH (in lib-simulation) is 2500; stepping fewer
         // times than that should never trigger evolution, and therefore
@@ -103,7 +123,7 @@ mod tests {
 
     #[test]
     fn generation_stats_reflects_the_current_generation_and_fitness_values() {
-        let simulation = Simulation::new();
+        let simulation = Simulation::new(None, None, None, None, None);
         let stats = lib_simulation::Statistics::new(&[
             AnimalIndividualStub(1.0),
             AnimalIndividualStub(3.0),

--- a/libs/simulation/src/lib.rs
+++ b/libs/simulation/src/lib.rs
@@ -61,21 +61,66 @@ const ROTATION_ACCEL: f32 = FRAC_PI_2;
 /// to live"; 2500 was chosen with a fair dice roll.
 const GENERATION_LENGTH: usize = 2500;
 
+/// Tunable knobs affecting how a [`Simulation`] is set up.
+///
+/// All fields have sane defaults (see [`Config::default`]) matching the
+/// values this simulation originally shipped with.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Config {
+    /// How many animals (birds) populate the world.
+    pub num_animals: usize,
+
+    /// How many foods populate the world.
+    pub num_foods: usize,
+
+    /// Probability of a single gene mutating during evolution.
+    ///
+    /// - 0.0 = no genes will be touched
+    /// - 1.0 = all genes will be touched
+    pub mutation_chance: f32,
+
+    /// Magnitude of a mutation, when it happens.
+    ///
+    /// - 0.0 = touched genes will not be modified
+    /// - 1.0 = touched genes will be += or -= by at most 3.0
+    pub mutation_coeff: f32,
+
+    /// Maximum speed a bird can reach.
+    pub max_speed: f32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            num_animals: 40,
+            num_foods: 60,
+            mutation_chance: 0.01,
+            mutation_coeff: 0.3,
+            max_speed: SPEED_MAX,
+        }
+    }
+}
+
 pub struct Simulation {
     world: World,
     ga: ga::GeneticAlgorithm<ga::RouletteWheelSelection>,
     age: usize,
     generation: usize,
+    max_speed: f32,
 }
 
 impl Simulation {
     pub fn random(rng: &mut dyn Rng) -> Self {
-        let world = World::random(rng);
+        Self::random_with_config(rng, Config::default())
+    }
+
+    pub fn random_with_config(rng: &mut dyn Rng, config: Config) -> Self {
+        let world = World::random_with(rng, config.num_animals, config.num_foods);
 
         let ga = ga::GeneticAlgorithm::new(
             ga::RouletteWheelSelection::new(),
             ga::UniformCrossover,
-            ga::GaussianMutation::new(0.01, 0.3),
+            ga::GaussianMutation::new(config.mutation_chance, config.mutation_coeff),
         );
 
         Self {
@@ -83,6 +128,7 @@ impl Simulation {
             ga,
             age: 0,
             generation: 0,
+            max_speed: config.max_speed,
         }
     }
 
@@ -145,7 +191,7 @@ impl Simulation {
 
             let rotation = response[1].clamp(-ROTATION_ACCEL, ROTATION_ACCEL);
 
-            animal.speed = (animal.speed + speed).clamp(SPEED_MIN, SPEED_MAX);
+            animal.speed = (animal.speed + speed).clamp(SPEED_MIN, self.max_speed);
 
             animal.rotation = na::Rotation2::new(animal.rotation.angle() + rotation);
         }
@@ -251,5 +297,50 @@ mod tests {
 
         assert_eq!(simulation.world().animals().len(), 40);
         assert_eq!(simulation.world().foods().len(), 60);
+    }
+
+    #[test]
+    fn config_default_matches_the_historical_hard_coded_values() {
+        let config = Config::default();
+
+        assert_eq!(config.num_animals, 40);
+        assert_eq!(config.num_foods, 60);
+        assert_eq!(config.mutation_chance, 0.01);
+        assert_eq!(config.mutation_coeff, 0.3);
+        assert_eq!(config.max_speed, SPEED_MAX);
+    }
+
+    #[test]
+    fn random_with_config_honors_the_requested_population_size() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let config = Config {
+            num_animals: 5,
+            num_foods: 7,
+            ..Config::default()
+        };
+
+        let simulation = Simulation::random_with_config(&mut rng, config);
+
+        assert_eq!(simulation.world().animals().len(), 5);
+        assert_eq!(simulation.world().foods().len(), 7);
+    }
+
+    #[test]
+    fn random_with_config_honors_the_requested_max_speed() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let config = Config {
+            // Force every bird to accelerate to (and stay clamped at) a
+            // tiny max speed within a single step.
+            max_speed: 0.0011,
+            ..Config::default()
+        };
+
+        let mut simulation = Simulation::random_with_config(&mut rng, config);
+
+        simulation.step(&mut rng);
+
+        for animal in simulation.world().animals() {
+            assert!(animal.speed <= config.max_speed);
+        }
     }
 }

--- a/libs/simulation/src/world.rs
+++ b/libs/simulation/src/world.rs
@@ -8,9 +8,13 @@ pub struct World {
 
 impl World {
     pub fn random(rng: &mut dyn Rng) -> Self {
-        let animals = (0..40).map(|_| Animal::random(rng)).collect();
+        Self::random_with(rng, 40, 60)
+    }
 
-        let foods = (0..60).map(|_| Food::random(rng)).collect();
+    pub fn random_with(rng: &mut dyn Rng, num_animals: usize, num_foods: usize) -> Self {
+        let animals = (0..num_animals).map(|_| Animal::random(rng)).collect();
+
+        let foods = (0..num_foods).map(|_| Food::random(rng)).collect();
 
         Self { animals, foods }
     }
@@ -37,6 +41,15 @@ mod tests {
 
         assert_eq!(world.animals().len(), 40);
         assert_eq!(world.foods().len(), 60);
+    }
+
+    #[test]
+    fn random_with_creates_the_requested_counts() {
+        let mut rng = ChaCha8Rng::from_seed(Default::default());
+        let world = World::random_with(&mut rng, 12, 34);
+
+        assert_eq!(world.animals().len(), 12);
+        assert_eq!(world.foods().len(), 34);
     }
 
     #[test]

--- a/www/index.html
+++ b/www/index.html
@@ -81,6 +81,49 @@
     height: 10px;
     border-radius: 2px;
   }
+
+  #config {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    margin: 15px;
+    padding: 10px 14px;
+    border-radius: 6px;
+    background: rgba(59, 70, 100, 0.85);
+    color: #e6e9f0;
+    font-size: 13px;
+  }
+
+  #config h4 {
+    margin: 0 0 8px 0;
+    font-size: 13px;
+  }
+
+  #config label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 6px;
+  }
+
+  #config input {
+    width: 90px;
+  }
+
+  #config button {
+    cursor: pointer;
+    padding: 5px 10px;
+    border: none;
+    border-radius: 4px;
+    background: #3b4664;
+    color: #e6e9f0;
+    margin-top: 4px;
+  }
+
+  #config button:hover {
+    background: #4c5a80;
+  }
 </style>
 
 <body>
@@ -106,6 +149,16 @@
       <span><i style="background: rgb(99, 170, 255)"></i>min</span>
     </div>
     <canvas id="chart" width="360" height="140"></canvas>
+  </div>
+
+  <div id="config">
+    <h4>simulation config</h4>
+    <label>animals <input id="cfg-num-animals" type="number" min="1" max="500" step="1" value="40"></label>
+    <label>foods <input id="cfg-num-foods" type="number" min="1" max="500" step="1" value="60"></label>
+    <label>mutation chance <input id="cfg-mutation-chance" type="number" min="0" max="1" step="0.01" value="0.01"></label>
+    <label>mutation coeff <input id="cfg-mutation-coeff" type="number" min="0" max="1" step="0.01" value="0.3"></label>
+    <label>max speed <input id="cfg-max-speed" type="number" min="0.001" max="0.05" step="0.001" value="0.005"></label>
+    <button id="config-apply">apply &amp; reset</button>
   </div>
 
   <script src="./bootstrap.js"></script>

--- a/www/index.js
+++ b/www/index.js
@@ -21,6 +21,13 @@ const statMin = document.getElementById('stat-min');
 const statMax = document.getElementById('stat-max');
 const statAvg = document.getElementById('stat-avg');
 
+const cfgNumAnimals = document.getElementById('cfg-num-animals');
+const cfgNumFoods = document.getElementById('cfg-num-foods');
+const cfgMutationChance = document.getElementById('cfg-mutation-chance');
+const cfgMutationCoeff = document.getElementById('cfg-mutation-coeff');
+const cfgMaxSpeed = document.getElementById('cfg-max-speed');
+const configApplyBtn = document.getElementById('config-apply');
+
 let isPaused = false;
 
 // History of per-generation fitness stats, used to draw the chart.
@@ -113,6 +120,21 @@ pauseBtn.onclick = function () {
 
 resetBtn.onclick = function () {
     simulation = new sim.Simulation();
+    resetStats();
+};
+
+function readConfigFromInputs() {
+    return [
+        parseInt(cfgNumAnimals.value, 10),
+        parseInt(cfgNumFoods.value, 10),
+        parseFloat(cfgMutationChance.value),
+        parseFloat(cfgMutationCoeff.value),
+        parseFloat(cfgMaxSpeed.value),
+    ];
+}
+
+configApplyBtn.onclick = function () {
+    simulation = new sim.Simulation(...readConfigFromInputs());
     resetStats();
 };
 


### PR DESCRIPTION
- lib-simulation: introduce a Config struct (num_animals, num_foods, mutation_chance, mutation_coeff, max_speed) with a Default impl matching the previous hard-coded values. Add Simulation::random_with_config(); Simulation::random() now delegates to it with Config::default() for backward compatibility.
- World::random_with() accepts explicit animal/food counts; World::random() keeps the old 40/60 defaults.
- lib-simulation-wasm: extend the wasm-bindgen Simulation constructor with optional parameters (num_animals, num_foods, mutation_chance, mutation_coeff, max_speed) so JS can pass undefined to fall back to defaults, with basic clamping for safety.
- www: add a small config panel (animal/food counts, mutation chance/ coeff, max speed) with an Apply & Reset button that reconstructs the simulation with the chosen parameters and resets the stats/chart.
- Added/updated unit tests for Config defaults, random_with_config, and World::random_with.