### PR TITLE
Add visual polish: bird trails, live counts, light/dark theme toggle

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -6,9 +6,31 @@
   <title>Shorelark</title>
 </head>
 <style>
+  :root {
+    --bg: #1f2639;
+    --panel-bg: rgba(59, 70, 100, 0.85);
+    --text: #e6e9f0;
+    --btn-bg: #3b4664;
+    --btn-bg-hover: #4c5a80;
+    --viewport-bg: #1f2639;
+  }
+
+  body.light {
+    --bg: #eef1f8;
+    --panel-bg: rgba(255, 255, 255, 0.85);
+    --text: #1f2639;
+    --btn-bg: #d7dcec;
+    --btn-bg-hover: #c2c9e0;
+    --viewport-bg: #ffffff;
+  }
+
   body {
-    background: #1f2639;
+    background: var(--bg);
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+
+  #viewport {
+    background: var(--viewport-bg);
   }
 
   #controls {
@@ -25,12 +47,12 @@
     padding: 6px 12px;
     border: none;
     border-radius: 4px;
-    background: #3b4664;
-    color: #e6e9f0;
+    background: var(--btn-bg);
+    color: var(--text);
   }
 
   #controls button:hover {
-    background: #4c5a80;
+    background: var(--btn-bg-hover);
   }
 
   #stats {
@@ -40,8 +62,8 @@
     margin: 15px;
     padding: 10px 14px;
     border-radius: 6px;
-    background: rgba(59, 70, 100, 0.85);
-    color: #e6e9f0;
+    background: var(--panel-bg);
+    color: var(--text);
     font-size: 14px;
     line-height: 1.6;
     min-width: 180px;
@@ -58,8 +80,8 @@
     margin: 15px;
     padding: 10px 14px;
     border-radius: 6px;
-    background: rgba(59, 70, 100, 0.85);
-    color: #e6e9f0;
+    background: var(--panel-bg);
+    color: var(--text);
     font-size: 12px;
   }
 
@@ -89,8 +111,8 @@
     margin: 15px;
     padding: 10px 14px;
     border-radius: 6px;
-    background: rgba(59, 70, 100, 0.85);
-    color: #e6e9f0;
+    background: var(--panel-bg);
+    color: var(--text);
     font-size: 13px;
   }
 
@@ -116,13 +138,13 @@
     padding: 5px 10px;
     border: none;
     border-radius: 4px;
-    background: #3b4664;
-    color: #e6e9f0;
+    background: var(--btn-bg);
+    color: var(--text);
     margin-top: 4px;
   }
 
   #config button:hover {
-    background: #4c5a80;
+    background: var(--btn-bg-hover);
   }
 </style>
 
@@ -133,10 +155,14 @@
     <button id="train">train please, thank u</button>
     <button id="pause">pause</button>
     <button id="reset">reset</button>
+    <button id="trails">trails: on</button>
+    <button id="theme">🌙 dark</button>
   </div>
 
   <div id="stats">
     generation: <span id="stat-generation">0</span><br>
+    animals: <span id="stat-animals">-</span><br>
+    foods: <span id="stat-foods">-</span><br>
     min fitness: <span id="stat-min">-</span><br>
     max fitness: <span id="stat-max">-</span><br>
     avg fitness: <span id="stat-avg">-</span>

--- a/www/index.js
+++ b/www/index.js
@@ -28,7 +28,15 @@ const cfgMutationCoeff = document.getElementById('cfg-mutation-coeff');
 const cfgMaxSpeed = document.getElementById('cfg-max-speed');
 const configApplyBtn = document.getElementById('config-apply');
 
+const statAnimals = document.getElementById('stat-animals');
+const statFoods = document.getElementById('stat-foods');
+
+const trailsBtn = document.getElementById('trails');
+const themeBtn = document.getElementById('theme');
+
 let isPaused = false;
+let trailsEnabled = true;
+let isLightTheme = false;
 
 // History of per-generation fitness stats, used to draw the chart.
 // Capped so the chart stays readable and memory bounded over long runs.
@@ -121,6 +129,7 @@ pauseBtn.onclick = function () {
 resetBtn.onclick = function () {
     simulation = new sim.Simulation();
     resetStats();
+    ctxt.clearRect(0, 0, viewportWidth, viewportHeight);
 };
 
 function readConfigFromInputs() {
@@ -136,9 +145,41 @@ function readConfigFromInputs() {
 configApplyBtn.onclick = function () {
     simulation = new sim.Simulation(...readConfigFromInputs());
     resetStats();
+    ctxt.clearRect(0, 0, viewportWidth, viewportHeight);
 };
 
-CanvasRenderingContext2D.prototype.drawTriangle = function (x, y, size, rotation) {
+trailsBtn.onclick = function () {
+    trailsEnabled = !trailsEnabled;
+    trailsBtn.textContent = trailsEnabled ? 'trails: on' : 'trails: off';
+
+    if (!trailsEnabled) {
+        ctxt.clearRect(0, 0, viewportWidth, viewportHeight);
+    }
+};
+
+themeBtn.onclick = function () {
+    isLightTheme = !isLightTheme;
+    document.body.classList.toggle('light', isLightTheme);
+    themeBtn.textContent = isLightTheme ? '☀️ light' : '🌙 dark';
+    updateThemeColors();
+    ctxt.clearRect(0, 0, viewportWidth, viewportHeight);
+};
+
+// Colors used when drawing on the <canvas>; kept in sync with the CSS
+// theme variables so trails/birds look right in both light and dark mode.
+let viewportBgColor = 'rgb(31, 38, 57)';
+let birdColor = 'rgb(255, 255, 255)';
+
+function updateThemeColors() {
+    viewportBgColor = isLightTheme ? 'rgb(255, 255, 255)' : 'rgb(31, 38, 57)';
+    birdColor = isLightTheme ? 'rgb(31, 38, 57)' : 'rgb(255, 255, 255)';
+}
+
+function toRgba(rgb, alpha) {
+    return rgb.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`);
+}
+
+CanvasRenderingContext2D.prototype.drawTriangle = function (x, y, size, rotation, color) {
     this.beginPath();
 
     this.moveTo(
@@ -163,7 +204,7 @@ CanvasRenderingContext2D.prototype.drawTriangle = function (x, y, size, rotation
     );
 
     this.stroke();
-    this.fillStyle = 'rgb(255, 255, 255)';
+    this.fillStyle = color;
     this.fill();
 }
 
@@ -178,7 +219,15 @@ CanvasRenderingContext2D.prototype.drawCircle = function (x, y, radius) {
 
 function redraw() {
     if (!isPaused) {
-        ctxt.clearRect(0, 0, viewportWidth, viewportHeight);
+        if (trailsEnabled) {
+            // Instead of a full clear, paint a translucent rectangle over
+            // the previous frame so past positions fade out gradually,
+            // leaving a short motion trail behind each bird.
+            ctxt.fillStyle = toRgba(viewportBgColor, 0.15);
+            ctxt.fillRect(0, 0, viewportWidth, viewportHeight);
+        } else {
+            ctxt.clearRect(0, 0, viewportWidth, viewportHeight);
+        }
 
         const stats = simulation.step();
 
@@ -189,6 +238,9 @@ function redraw() {
         recordStats(stats);
 
         const world = simulation.world();
+
+        statAnimals.textContent = world.animals.length;
+        statFoods.textContent = world.foods.length;
 
         for (const food of world.foods) {
             ctxt.drawCircle(
@@ -204,6 +256,7 @@ function redraw() {
                 animal.y * viewportHeight,
                 0.01 * viewportWidth,
                 animal.rotation,
+                birdColor,
             );
         }
     }


### PR DESCRIPTION
- www: fading motion trails behind birds (toggleable via a new 'trails' button) using a translucent overlay instead of a hard canvas clear each frame.
- www: stats panel now shows live animal/food counts alongside generation and fitness stats.
- www: add a light/dark theme toggle button; CSS custom properties drive panel/button colors, and the canvas background/bird/trail colors are kept in sync with the active theme.