### PR TITLE
Add simulation speed / fast-forward control

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -146,6 +146,15 @@
   #config button:hover {
     background: var(--btn-bg-hover);
   }
+
+  #controls select {
+    cursor: pointer;
+    padding: 6px 8px;
+    border: none;
+    border-radius: 4px;
+    background: var(--btn-bg);
+    color: var(--text);
+  }
 </style>
 
 <body>
@@ -157,6 +166,14 @@
     <button id="reset">reset</button>
     <button id="trails">trails: on</button>
     <button id="theme">🌙 dark</button>
+    <select id="speed" title="simulation speed">
+      <option value="1">1x</option>
+      <option value="2">2x</option>
+      <option value="5">5x</option>
+      <option value="10">10x</option>
+      <option value="25">25x</option>
+      <option value="50">50x</option>
+    </select>
   </div>
 
   <div id="stats">

--- a/www/index.js
+++ b/www/index.js
@@ -33,10 +33,12 @@ const statFoods = document.getElementById('stat-foods');
 
 const trailsBtn = document.getElementById('trails');
 const themeBtn = document.getElementById('theme');
+const speedSelect = document.getElementById('speed');
 
 let isPaused = false;
 let trailsEnabled = true;
 let isLightTheme = false;
+let simSpeed = 1;
 
 // History of per-generation fitness stats, used to draw the chart.
 // Capped so the chart stays readable and memory bounded over long runs.
@@ -165,6 +167,10 @@ themeBtn.onclick = function () {
     ctxt.clearRect(0, 0, viewportWidth, viewportHeight);
 };
 
+speedSelect.onchange = function () {
+    simSpeed = parseInt(speedSelect.value, 10) || 1;
+};
+
 // Colors used when drawing on the <canvas>; kept in sync with the CSS
 // theme variables so trails/birds look right in both light and dark mode.
 let viewportBgColor = 'rgb(31, 38, 57)';
@@ -236,6 +242,17 @@ function redraw() {
         }
 
         recordStats(stats);
+
+        // Fast-forward: run the remaining steps for this frame without
+        // re-rendering in between, so higher speeds actually save wall
+        // time instead of just rendering faster.
+        for (let i = 1; i < simSpeed; i++) {
+            const extraStats = simulation.step();
+
+            if (extraStats) {
+                recordStats(extraStats);
+            }
+        }
 
         const world = simulation.world();
 


### PR DESCRIPTION
- www: add a speed selector (1x/2x/5x/10x/25x/50x) to the controls bar. At speeds above 1x, multiple simulation steps run per rendered animation frame (only the final state is drawn), so training progresses much faster in wall-clock time instead of just rendering faster.
- Stats are recorded for every generation that completes within a batch of steps, so the chart/stats stay accurate even at high speeds.